### PR TITLE
Bugfix: conditional rendering of draw polygon tool

### DIFF
--- a/src/ReduxMap/reduxmap.jsx
+++ b/src/ReduxMap/reduxmap.jsx
@@ -272,10 +272,17 @@ const ReduxMap = ({
       simpleSelect.dragMove = () => {};
       directSelect.dragFeature = () => {};
 
+      // Prevents selecting the polygon if hasDrawing is false
+      if (!hasDrawing) {
+        simpleSelect.onClick = () => {};
+        simpleSelect.onMouseDown = () => {};
+        simpleSelect.onTouchStart = () => {};
+      }
+
       // DRAWER CONTROL
       const Draw = new MapboxDraw({
         displayControlsDefault: false,
-        controls: { polygon: true, trash: true },
+        controls: hasDrawing ? { polygon: true, trash: true } : {}, // Only show the controls if hasDrawing is true
         modes: {
           ...MapboxDraw.modes,
           simple_select: simpleSelect,
@@ -295,7 +302,7 @@ const ReduxMap = ({
       // ADD CONTROLS
       if (hasFullScreen) map.current.addControl(Fullscreen, "top-right");
       if (hasNavigation) map.current.addControl(Navigation, "top-right"); // causes warning
-      if (hasDrawing) map.current.addControl(Draw, "top-right");
+      map.current.addControl(Draw, "top-right");
 
       // CUSTOM CONTROLS
       if (hasFreehand)

--- a/src/ReduxMap/reduxmap.jsx
+++ b/src/ReduxMap/reduxmap.jsx
@@ -273,7 +273,7 @@ const ReduxMap = ({
       directSelect.dragFeature = () => {};
 
       // Prevents selecting the polygon if hasDrawing is false
-      if (!hasDrawing) {
+      if (!hasDrawing && !hasFreehand) {
         simpleSelect.onClick = () => {};
         simpleSelect.onMouseDown = () => {};
         simpleSelect.onTouchStart = () => {};
@@ -282,7 +282,7 @@ const ReduxMap = ({
       // DRAWER CONTROL
       const Draw = new MapboxDraw({
         displayControlsDefault: false,
-        controls: hasDrawing ? { polygon: true, trash: true } : {}, // Only show the controls if hasDrawing is true
+        controls: (hasDrawing || hasFreehand) ? { polygon: true, trash: true } : {}, // Only show the controls if hasDrawing is true
         modes: {
           ...MapboxDraw.modes,
           simple_select: simpleSelect,


### PR DESCRIPTION
-  problem: polygons don't appear unless `hasDrawing` is true, which also adds the polygon tool - this makes displaying a polygon without the polygon tool not possible 
- the fix allows displaying of polygons even when `hasDrawing` is false. And the polygon tool only appears when `hasDrawing` is true